### PR TITLE
bump to Lmod 6.5.7

### DIFF
--- a/Lmod-UGent.spec
+++ b/Lmod-UGent.spec
@@ -1,7 +1,7 @@
 %global macrosdir %(d=%{_rpmconfigdir}/macros.d; [ -d $d ] || d=%{_sysconfdir}/rpm; echo $d)
 
 Name:           Lmod
-Version:        6.5.7
+Version:        6.5.8
 Release:        1.ug%{?dist}
 Summary:        Environmental Modules System in Lua
 

--- a/Lmod-UGent.spec
+++ b/Lmod-UGent.spec
@@ -1,7 +1,7 @@
 %global macrosdir %(d=%{_rpmconfigdir}/macros.d; [ -d $d ] || d=%{_sysconfdir}/rpm; echo $d)
 
 Name:           Lmod
-Version:        6.5.5
+Version:        6.5.7
 Release:        1.ug%{?dist}
 Summary:        Environmental Modules System in Lua
 

--- a/SitePackage.lua
+++ b/SitePackage.lua
@@ -1,11 +1,13 @@
 --------------------------------------------------------------------------
 -- The SitePackage customization for UGent-HPC
 -- Ward Poelmans <ward.poelmans@ugent.be>
+-- Kenneth Hoste <kenneth.hoste@ugent.be>
 --------------------------------------------------------------------------
 
 require("strict")
 require("cmdfuncs")
 require("utils")
+require("lmod_system_execute")
 local Dbg   = require("Dbg")
 local dbg   = Dbg:dbg()
 local hook  = require("Hook")
@@ -30,7 +32,7 @@ local function logmsg(logTbl)
         msg = msg .. string.format(", %s=%s", val[1], val[2] or "")
     end
 
-    os.execute("logger -t lmod -p user.notice -- " .. msg)
+    lmod_system_execute("logger -t lmod -p user.notice -- " .. msg)
 end
 
 


### PR DESCRIPTION
Lmod 6.5.7 fixes a bug that we encountered in EasyBuild where a module for a dependency that sets `$LD_PRELOAD` (e.g. `jemalloc`) breaks subsequent loads of other dependencies (e.g. `PCRE`) when a Tcl module file is being loaded (e.g. `MariaDB`), due to EasyBuild resetting `$LD_LIBRARY_PATH` after having loading the toolchain first

This problem can be reproduced with:

```
$ ml intel/2016a && LD_LIBRARY_PATH='' LD_PRELOAD='' ml MariaDB/10.1.14-intel-2016a
sh: error while loading shared libraries: libiomp5.so: cannot open shared object file: No such file or directory
sh: error while loading shared libraries: libiomp5.so: cannot open shared object file: No such file or directory
Lmod has detected the following error:  Failed to find 'Lmod Capture Exit Code' in output: 
While processing the following module(s):
    Module fullname              Module Filename
    ---------------              ---------------
    PCRE/8.38-intel-2016a        /apps/gent/SL6/sandybridge/modules/all/PCRE/8.38-intel-2016a
    MariaDB/10.1.14-intel-2016a  /apps/gent/SL6/sandybridge/modules/all/MariaDB/10.1.14-intel-2016a

If you don't understand the warning or error, contact the helpdesk at hpc@ugent.be

```

Note that although the resetting of `$LD_LIBRARY_PATH` as done by EasyBuild should be followed by properly merging the original `$LD_LIBRARY_PATH` with the value obtained from the `ml load` statement; if not, lots of commands will be broken because of `$LD_PRELOAD` listing a library that needs other libraries which are no longer available via `$LD_LIBRARY_PATH`...
