### PR TITLE
Give nicer error to users when loading modules from different toolchains

### DIFF
--- a/Lmod-UGent.spec
+++ b/Lmod-UGent.spec
@@ -1,7 +1,7 @@
 %global macrosdir %(d=%{_rpmconfigdir}/macros.d; [ -d $d ] || d=%{_sysconfdir}/rpm; echo $d)
 
 Name:           Lmod
-Version:        6.5.11
+Version:        6.5.12
 Release:        1.ug%{?dist}
 Summary:        Environmental Modules System in Lua
 

--- a/Lmod-UGent.spec
+++ b/Lmod-UGent.spec
@@ -1,7 +1,7 @@
 %global macrosdir %(d=%{_rpmconfigdir}/macros.d; [ -d $d ] || d=%{_sysconfdir}/rpm; echo $d)
 
 Name:           Lmod
-Version:        6.5.12
+Version:        6.5.14
 Release:        1.ug%{?dist}
 Summary:        Environmental Modules System in Lua
 

--- a/Lmod-UGent.spec
+++ b/Lmod-UGent.spec
@@ -1,7 +1,7 @@
 %global macrosdir %(d=%{_rpmconfigdir}/macros.d; [ -d $d ] || d=%{_sysconfdir}/rpm; echo $d)
 
 Name:           Lmod
-Version:        6.5.10
+Version:        6.5.11
 Release:        1.ug%{?dist}
 Summary:        Environmental Modules System in Lua
 

--- a/SitePackage.lua
+++ b/SitePackage.lua
@@ -132,6 +132,26 @@ local function msg_hook(mode, output)
 
     dbg.print{"Mode is ", mode, "\n"}
 
+    if output[1] and output[1]:find("Your site prevents the automatic swapping of modules with same name") then
+        -- find the module name causing the issue (almost always toolchain module)
+        local fname, mname
+        mname, fname = output[1]:match("$ module swap ([^ ]+)%s+([^ \n]+)")
+        local mStack   = ModuleStack:moduleStack()
+
+        local label  = colorize("red", "Lmod has detected the following error: ")
+        local twidth = TermWidth()
+        local s      = {}
+        s[#s+1] = buildMsg(twidth, label, "You can not load modules using different toolchains.",
+                                          "A different version of the '"..mname.."' module is already",
+                                          "loaded (see output of 'ml').\nYou should load another ",
+                                          "'"..mStack:sn().."' module for that is compatible with the ",
+                                          "currently loaded version of '"..mname.."'. Use 'ml spider",
+                                          ""..mStack:sn().."' to get an overview of the available versions.")
+        s[#s+1] = "\n"
+
+        output[1] = table.concat(s,"")
+    end
+
     if mode == "avail" then
         output[#output+1] = "\nIf you need software that is not listed, request it at hpc@ugent.be\n"
     elseif mode == "lmoderror" or mode == "lmodwarning" then

--- a/SitePackage.lua
+++ b/SitePackage.lua
@@ -147,14 +147,18 @@ local function msg_hook(mode, output)
         local twidth = TermWidth()
         local s      = {}
         s[#s+1]      = buildMsg(twidth, label, table.concat(errmsg, "\n"))
-        s[#s+1]      = "\n"
         output[1]    = table.concat(s, "")
     end
 
     if mode == "avail" then
         output[#output+1] = "\nIf you need software that is not listed, request it at hpc@ugent.be\n"
     elseif mode == "lmoderror" or mode == "lmodwarning" then
-        output[#output+1] = "\nIf you don't understand the warning or error, contact the helpdesk at hpc@ugent.be\n"
+        -- until https://github.com/TACC/Lmod/pull/166 is merged
+        if output[#output] ~= "\n" or output[#output-1] ~= '' then
+            output[#output+1] = "\n"
+        end
+        output[#output+1] = "If you don't understand the warning or error, contact the helpdesk at hpc@ugent.be"
+        output[#output+1] = "\n"
     end
 
     dbg.fini()

--- a/SitePackage.lua
+++ b/SitePackage.lua
@@ -134,22 +134,22 @@ local function msg_hook(mode, output)
 
     if output[1] and output[1]:find("Your site prevents the automatic swapping of modules with same name") then
         -- find the module name causing the issue (almost always toolchain module)
-        local mname
-        mname = output[1]:match("$ module swap [^ ]+%s+([^ \n]+)")
-        local mStack   = ModuleStack:moduleStack()
+        local sname  = output[1]:match("$ module swap ([^ ]+)%s+[^ \n]+")
+        local mStack = ModuleStack:moduleStack()
+
+        local errmsg = {"A different version of the '"..sname.."' module is already loaded (see output of 'ml')."}
+        if not mStack:empty() then
+            errmsg[#errmsg+1] = " You should load another '"..mStack:sn().."' module for that is compatible with the "
+            errmsg[#errmsg+1] = "currently loaded version of '"..sname.."'. Use 'ml spider "..mStack:sn().."' to get "
+            errmsg[#errmsg+1] = "an overview of the available versions."
+        end
 
         local label  = colorize("red", "Lmod has detected the following error: ")
         local twidth = TermWidth()
         local s      = {}
-        s[#s+1] = buildMsg(twidth, label, "You can not load modules using different toolchains.",
-                                          "A different version of the '"..mname.."' module is already",
-                                          "loaded (see output of 'ml').\nYou should load another ",
-                                          "'"..mStack:sn().."' module for that is compatible with the ",
-                                          "currently loaded version of '"..mname.."'. Use 'ml spider",
-                                          ""..mStack:sn().."' to get an overview of the available versions.")
-        s[#s+1] = "\n"
-
-        output[1] = table.concat(s,"")
+        s[#s+1]      = buildMsg(twidth, label, table.concat(errmsg, ""))
+        s[#s+1]      = "\n"
+        output[1]    = table.concat(s, "")
     end
 
     if mode == "avail" then

--- a/SitePackage.lua
+++ b/SitePackage.lua
@@ -134,8 +134,8 @@ local function msg_hook(mode, output)
 
     if output[1] and output[1]:find("Your site prevents the automatic swapping of modules with same name") then
         -- find the module name causing the issue (almost always toolchain module)
-        local fname, mname
-        mname, fname = output[1]:match("$ module swap ([^ ]+)%s+([^ \n]+)")
+        local mname
+        mname = output[1]:match("$ module swap [^ ]+%s+([^ \n]+)")
         local mStack   = ModuleStack:moduleStack()
 
         local label  = colorize("red", "Lmod has detected the following error: ")

--- a/SitePackage.lua
+++ b/SitePackage.lua
@@ -139,15 +139,14 @@ local function msg_hook(mode, output)
 
         local errmsg = {"A different version of the '"..sname.."' module is already loaded (see output of 'ml')."}
         if not mStack:empty() then
-            errmsg[#errmsg+1] = " You should load another '"..mStack:sn().."' module for that is compatible with the "
-            errmsg[#errmsg+1] = "currently loaded version of '"..sname.."'. Use 'ml spider "..mStack:sn().."' to get "
-            errmsg[#errmsg+1] = "an overview of the available versions."
+            errmsg[#errmsg+1] = "You should load another '"..mStack:sn().."' module for that is compatible with the currently loaded version of '"..sname.."'."
+            errmsg[#errmsg+1] = "Use 'ml spider "..mStack:sn().."' to get an overview of the available versions."
         end
 
         local label  = colorize("red", "Lmod has detected the following error: ")
         local twidth = TermWidth()
         local s      = {}
-        s[#s+1]      = buildMsg(twidth, label, table.concat(errmsg, ""))
+        s[#s+1]      = buildMsg(twidth, label, table.concat(errmsg, "\n"))
         s[#s+1]      = "\n"
         output[1]    = table.concat(s, "")
     end


### PR DESCRIPTION
Fixes #9 

With this:

```
$ ml zlib/1.2.8-intel-2014b
$ ml ncurses
Lmod has detected the following error:  You can not load modules using different toolchains. A different version of the 'intel' module is already loaded (see output of 'ml').
You should load another 'ncurses' module for that is compatible with the currently loaded version of 'intel'. Use 'ml spider ncurses' to get an overview of the available versions. 

While processing the following module(s):
    Module fullname          Module Filename
    ---------------          ---------------
    ncurses/6.0-intel-2016a  /apps/gent/SL6/westmere/modules/all/ncurses/6.0-intel-2016a

If you don't understand the warning or error, contact the helpdesk at hpc@ugent.be

```
