### PR TITLE
add patch to ensure Lmod cache is used when loading cluster modules

### DIFF
--- a/Lmod-7.5.10_fix-chkMP-cache.patch
+++ b/Lmod-7.5.10_fix-chkMP-cache.patch
@@ -1,0 +1,19 @@
+make sure chkMP uses spider cache rather than triggering module tree walk for a prepend_path($MODULEPATH, ...)
+author: Kenneth Hoste (HPC-UGent)
+diff --git a/src/Var.lua b/src/Var.lua
+index 633ff2bc..68799697 100644
+--- a/src/Var.lua
++++ b/src/Var.lua
+@@ -104,9 +104,10 @@ local function chkMP(name, value, adding)
+       local mt = require("FrameStk"):singleton():mt()
+       mt:set_MPATH_change_flag()
+       mt:updateMPathA(value)
+-      local moduleA      = require("ModuleA"):singleton()
+       local cached_loads = cosmic:value("LMOD_CACHED_LOADS")
+-      moduleA:update{spider_cache = (cached_loads ~= 'no')}
++      local spider_cache = (cached_loads ~= 'no')
++      local moduleA      = require("ModuleA"):singleton{spider_cache = spider_cache}
++      moduleA:update{spider_cache = spider_cache}
+       dbg.fini("chkMP")
+    end
+ end

--- a/Lmod-UGent.spec
+++ b/Lmod-UGent.spec
@@ -2,7 +2,7 @@
 
 Name:           Lmod
 Version:        7.5.10
-Release:        6.ug%{?dist}
+Release:        7.ug%{?dist}
 Summary:        Environmental Modules System in Lua
 
 # Lmod-5.3.2/tools/base64.lua is LGPLv2
@@ -14,6 +14,7 @@ Source2:        SitePackage.lua
 Source3:        run_lmod_cache.py
 Source4:        admin.list
 Patch0:         Lmod-spider-no-hidden-cluster-modules.patch
+Patch1:         Lmod/Lmod-7.5.10_fix-chkMP-cache.patch
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 BuildArch:      noarch
@@ -41,6 +42,7 @@ where the library and header files can be found.
 %prep
 %setup -q
 %patch0 -p1
+%patch1 -p1
 sed -i -e 's,/usr/bin/env ,/usr/bin/,' src/*.tcl
 # Remove bundled lua-term
 rm -r pkgs tools/json.lua
@@ -90,6 +92,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Thu Jul 13 2017 Kenneth Hoste <kenneth.hoste@ugent.be> - 7.5.10-7.ug
+- add patch to ensure Lmod cache is used when loading cluster modules which include prepend_path($MODULEPATH, ...)
+
 * Fri Jul 7 2017 Kenneth Hoste <kenneth.hoste@ugent.be> - 7.5.10-6.ug
 - fix grabbing $MODULEPATH root from Lmod config in run_lmod_cache.py, 'config' was renamed to 'configT' in Lmod 7
 


### PR DESCRIPTION
PR https://github.com/TACC/Lmod/pull/300 was merged, but no new version was tagged yet. I see no reason to wait for that though...

Our integration tests pass with this installed:

```
[08:29:17] vsc40023@node2003:~/vsc-testing/module $ ./run_all_tests.sh

Lmod-7.5.10-7.ug.el7.centos.noarch
vsc-cluster-modules-0.21-1.noarch
vsc-cluster-modules-tier2-0.21-1.noarch

> module --version

Modules based on Lua: Version 7.5.10  2017-07-05 14:04 -05:00
$MODULEPATH: /apps/gent/CO7/sandybridge/modules/all:/apps/gent/SL6/sandybridge/modules/all:/etc/modulefiles/vsc

*** 001_list.sh ***

> module list

>>> 001_list.sh: PASS

*** 002_avail.sh ***

> module avail
> module avail GCC
> module avail GCC/4.9.3

>>> 002_avail.sh: PASS

*** 003_load.sh ***

> module load GCC
> module load GCC/4.9.3
> module load intel
> module load foss
> module load Python/2.7.11-intel-2016a
> module load GCC/4.9.3-2.25 OpenMPI/1.10.2-GCC-4.9.3-2.25 OpenBLAS/0.2.15-GCC-4.9.3-2.25-LAPACK-3.6.0 FFTW/3.3.4-gompi-2016a

>>> 003_load.sh: PASS

*** 004_purge.sh ***

> module load Python/2.7.11-intel-2016a
> module purge
> module load cluster
> module purge -force
> module load cluster
> module purge -force
> module load cluster/delcatty

>>> 004_purge.sh: PASS

*** 005_swap.sh ***

> module load GCC/4.9.3
> module swap GCC/5.3.0
> module swap GCC GCC/4.9.3
> module swap GCC/4.9.3 GCC/5.3.0

>>> 005_swap.sh: PASS

*** 006_unload.sh ***

> module load GCC/4.9.3
> module unload GCC
> module load GCC/4.9.3
> module unload GCC/4.9.3

>>> 006_unload.sh: PASS

*** 007_spider.sh ***

> module spider intel
> module spider intel/2016a
> module --show-hidden spider intel/2016a

>>> 007_spider.sh: PASS

*** 010_stdout_stderr.sh ***

> module list
> module avail

>>> 010_stdout_stderr.sh: PASS

*** 050_ml.sh ***

> ml av GCC/4.9.3
> ml
> ml GCC/4.9.3
> ml
> ml -GCC/4.9.3
> ml

>>> 050_ml.sh: PASS

*** 051_collections.sh ***

> ml foss/2016a
> ml Python/2.7.11-intel-2016a
> ml save this_is_just_a_test_collection_for_module_integration_test_051
> ml describe this_is_just_a_test_collection_for_module_integration_test_051
> ml purge
> ml restore this_is_just_a_test_collection_for_module_integration_test_051
> ml purge
> module swap cluster/delcatty cluster/golett
> ml purge
> ml restore this_is_just_a_test_collection_for_module_integration_test_051
> ml purge

>>> 051_collections.sh: PASS

*** 100_lmod_cache.sh ***

> module avail  # 2s time limit

>>> 100_lmod_cache.sh: PASS

*** 101_LD_LIBRARY_PATH.sh ***

> module load GCC/4.9.3-2.25
> module load OpenMPI/1.10.2-GCC-4.9.3-2.25
> checking $LD_LIBRARY_PATH...

>>> 101_LD_LIBRARY_PATH.sh: PASS

*** 102_symlink_modulepath.sh ***

> module use /tmp/vsc40023/afYWQX/symlinked_modules
> module avail test/1.2.3

>>> 102_symlink_modulepath.sh: PASS

*** 103_tcl2lua_LD_PRELOAD.sh ***

> module load jemalloc
> module show jemalloc
> ml intel/2016a && LD_LIBRARY_PATH='' LD_PRELOAD='' ml MariaDB/10.1.14-intel-2016a

>>> 103_tcl2lua_LD_PRELOAD.sh: PASS

TEST RESULT: all 14 passed!
```