### PR TITLE
update to Lmod 7.8.4 + update nag list

### DIFF
--- a/Lmod-UGent.spec
+++ b/Lmod-UGent.spec
@@ -1,8 +1,8 @@
 %global macrosdir %(d=%{_rpmconfigdir}/macros.d; [ -d $d ] || d=%{_sysconfdir}/rpm; echo $d)
 
 Name:           Lmod
-Version:        7.7.26
-Release:        3.ug%{?dist}
+Version:        7.8.4
+Release:        1.ug%{?dist}
 Summary:        Environmental Modules System in Lua
 
 # Lmod-5.3.2/tools/base64.lua is LGPLv2
@@ -90,6 +90,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Wed Sep 26 2018 Kenneth Hoste <kenneth.hoste@ugent.be> - 7.8.4-1.ug
+- update to Lmod 7.8.4 + tweak admin.list
+
 * Wed Apr 4 2018 Kenneth Hoste <kenneth.hoste@ugent.be> - 7.7.26-1.ug
 - update to Lmod 7.7.26 (clean error when cache file can not be read & more)
 

--- a/admin.list
+++ b/admin.list
@@ -30,3 +30,7 @@ jobs/1.0.2: Do not use the jobs module anymore. Load the vsc-mympirun module dir
 
 jobs/2.0.0: Do not use the jobs module anymore. Load the vsc-mympirun module directly.
 
+Stacks/2.0-intel-2018a:
+This Stacks installation is known to have problems,
+please use Stacks/2.0-foss-2018a or a more recent Stacks module instead.
+


### PR DESCRIPTION
`Stacks/2.0-intel-2018a` is knows to result in segfaults, I'd rather make it clear to users that there's something wrong with the installation than just remove it.