### PR TITLE
update to Lmod 8.1.16 (HPC-7920)

### DIFF
--- a/Lmod-UGent.spec
+++ b/Lmod-UGent.spec
@@ -1,8 +1,8 @@
 %global macrosdir %(d=%{_rpmconfigdir}/macros.d; [ -d $d ] || d=%{_sysconfdir}/rpm; echo $d)
 
 Name:           Lmod
-Version:        7.8.19
-Release:        2.ug%{?dist}
+Version:        8.1.16
+Release:        1.ug%{?dist}
 Summary:        Environmental Modules System in Lua
 
 # Lmod-5.3.2/tools/base64.lua is LGPLv2
@@ -16,11 +16,14 @@ Source4:        admin.list
 Patch0:         Lmod-spider-no-hidden-cluster-modules.patch
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
-BuildArch:      noarch
+# Lmod 8.x ships binaries when configured with --with-fastTCLInterp=yes (which is the default)
+# BuildArch:      noarch
+BuildRequires:  lua-devel
 BuildRequires:  lua-filesystem
 BuildRequires:  lua-json
 BuildRequires:  lua-posix
 BuildRequires:  lua-term
+BuildRequires:  tcl-devel
 Requires:       lua-filesystem
 Requires:       lua-json
 Requires:       lua-posix
@@ -43,7 +46,7 @@ where the library and header files can be found.
 %patch0 -p1
 sed -i -e 's,/usr/bin/env ,/usr/bin/,' src/*.tcl
 # Remove bundled lua-term
-rm -r pkgs tools/json.lua
+rm -r pkgs/luafilesystem/ pkgs/term/ tools/json.lua
 sed -i -e 's/^spiderCacheSupport: lfs/spiderCacheSupport: /' Makefile.in
 # Remove unneeded shbangs
 sed -i -e '/^#!/d' init/*.in
@@ -90,6 +93,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Wed Aug 7 2019 Kenneth Hoste <kenneth.hoste@ugent.be> - 8.1.13-1.ug
+  - update to Lmod 8.1.16
+
 * Wed Sep 26 2018 Kenneth Hoste <kenneth.hoste@ugent.be> - 7.8.4-1.ug
 - update to Lmod 7.8.4 + tweak admin.list
 

--- a/Lmod-UGent.spec
+++ b/Lmod-UGent.spec
@@ -62,7 +62,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %make_install
 # init scripts are sourced
-chmod -x %{buildroot}%{_datadir}/lmod/%{version}/init/*
+find %{buildroot}%{_datadir}/lmod/%{version}/init/ -type f -print0 | xargs -0 chmod -x
 mkdir -p %{buildroot}%{_sysconfdir}/modulefiles
 mkdir -p %{buildroot}%{_datadir}/modulefiles
 mkdir -p %{buildroot}%{_sysconfdir}/profile.d


### PR DESCRIPTION
integration tests from `vsc-testing` repo pass with flying colors:
```
$ cd vsc-testing/module/
$ ./run_all_tests.sh
Lmod-8.1.16-1.ug.el7.x86_64
vsc-cluster-modules-0.35-2.noarch
vsc-cluster-modules-tier2-0.35-2.noarch

> module --version

Modules based on Lua: Version 8.1.16  2019-09-22 21:50 -05:00
$MODULEPATH: /apps/gent/CO7/haswell-ib/modules/all:/etc/modulefiles/vsc

*** 001_list.sh ***

> module list

>>> 001_list.sh: PASS

*** 002_avail.sh ***

> module avail
> module avail GCC
> module avail GCC/6.4.0

>>> 002_avail.sh: PASS

*** 003_load.sh ***

> module load GCC
> module load GCC/6.4.0-2.28
> module load intel
> module load foss
> module load Python/2.7.14-intel-2018a
> module load GCC/6.4.0-2.28 OpenMPI/2.1.2-GCC-6.4.0-2.28 OpenBLAS/0.2.20-GCC-6.4.0-2.28 FFTW/3.3.7-gompi-2018a
> module --force purge; module load cluster  # with 1 seconds time limit

>>> 003_load.sh: PASS

*** 004_purge.sh ***

> module load Python/2.7.14-intel-2018a
> module purge
> module load cluster
> module --force purge
> module load cluster
> module --force purge
> module load cluster/swalot

>>> 004_purge.sh: PASS

*** 005_swap.sh ***

> module load GCCcore/6.4.0
> module swap GCCcore/7.3.0
> module swap GCCcore GCCcore/6.4.0
> module swap GCCcore/6.4.0 GCCcore/7.3.0

>>> 005_swap.sh: PASS

*** 006_unload.sh ***

> module load GCCcore/6.4.0
> module unload GCCcore
> module load GCCcore/6.4.0
> module unload GCCcore/6.4.0

>>> 006_unload.sh: PASS

*** 007_spider.sh ***

> module spider intel
> module spider intel/2016a
> module --show-hidden spider intel/2016a

>>> 007_spider.sh: PASS

*** 010_stdout_stderr.sh ***

> module list
> module avail

>>> 010_stdout_stderr.sh: PASS

*** 050_ml.sh ***

> ml av GCCcore/6.4.0
> ml
> ml GCCcore/6.4.0
> ml
> ml -GCCcore/6.4.0
> ml

>>> 050_ml.sh: PASS

*** 051_collections.sh ***

> ml foss/2018a
> ml Python/2.7.14-intel-2018a
> module swap cluster/delcatty
> ml save this_is_just_a_test_collection_for_module_integration_test_051
> ml describe this_is_just_a_test_collection_for_module_integration_test_051
> module swap cluster/swalot
> ml save this_is_just_a_test_collection_for_module_integration_test_051
> ml describe this_is_just_a_test_collection_for_module_integration_test_051
> ml purge
> ml restore this_is_just_a_test_collection_for_module_integration_test_051
> ml purge
> module swap cluster/delcatty
> ml purge
> ml restore this_is_just_a_test_collection_for_module_integration_test_051
> ml purge

>>> 051_collections.sh: PASS

*** 100_lmod_cache.sh ***

> module avail  # 2s time limit

>>> 100_lmod_cache.sh: PASS

*** 101_LD_LIBRARY_PATH.sh ***

> module load GCC/6.4.0-2.28
> module load OpenMPI/2.1.2-GCC-6.4.0-2.28
> checking $LD_LIBRARY_PATH...

>>> 101_LD_LIBRARY_PATH.sh: PASS

*** 102_symlink_modulepath.sh ***

> module use /tmp/vsc40023/CugLhm/symlinked_modules
> module avail test/1.2.3

>>> 102_symlink_modulepath.sh: PASS

*** 103_tcl2lua_LD_PRELOAD.sh ***

> module load jemalloc
> module show jemalloc
> ml intel/2018a && LD_LIBRARY_PATH='' LD_PRELOAD='' ml MariaDB/10.3.7-intel-2018a

>>> 103_tcl2lua_LD_PRELOAD.sh: PASS

TEST RESULT: all 14 passed!
```