### PR TITLE
update to Lmod 8.2.5 (HPC-7920)

### DIFF
--- a/Lmod-UGent.spec
+++ b/Lmod-UGent.spec
@@ -1,7 +1,7 @@
 %global macrosdir %(d=%{_rpmconfigdir}/macros.d; [ -d $d ] || d=%{_sysconfdir}/rpm; echo $d)
 
 Name:           Lmod
-Version:        8.1.17
+Version:        8.2.5
 Release:        1.ug%{?dist}
 Summary:        Environmental Modules System in Lua
 
@@ -93,6 +93,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Tue Nov 26 2019 Kenneth Hoste <kenneth.hoste@ugent.be> - 8.2.5-1.ug
+  - update to Lmod 8.2.5 (support for extensions)
+
 * Tue Sep 24 2019 Kenneth Hoste <kenneth.hoste@ugent.be> - 8.1.17-1.ug
   - update to Lmod 8.1.17 (restores 'module switch')
 

--- a/Lmod-spider-no-hidden-cluster-modules.patch
+++ b/Lmod-spider-no-hidden-cluster-modules.patch
@@ -1,17 +1,17 @@
 diff --git a/src/Spider.lua b/src/Spider.lua
-index 587ff3c1..84d08d95 100644
+index 095a8f44..ec89b33b 100644
 --- a/src/Spider.lua
 +++ b/src/Spider.lua
-@@ -971,8 +971,10 @@ function M._Level2(self, sn, entryA, possibleA)
-          for j = 1, #entryT.parentAA do
-             local parentA = entryT.parentAA[j]
-             for i = 1, #parentA do
--               b[#b+1] = parentA[i]
--               b[#b+1] = '  '
-+               if show_hidden or not parentA[i]:find("cluster/%.") then
-+                 b[#b+1] = parentA[i]
-+                 b[#b+1] = '  '
-+               end
+@@ -1282,8 +1282,10 @@ function M._Level2(self, sn, fullName, entryA, entryPA, possibleA, tailMsg)
+             for j = 1, #entryT.parentAA do
+                local parentA = entryT.parentAA[j]
+                for i = 1, #parentA do
+-                  b[#b+1] = parentA[i]
+-                  b[#b+1] = '  '
++                  if show_hidden or not parentA[i]:find("cluster/%.") then
++                     b[#b+1] = parentA[i]
++                     b[#b+1] = '  '
++                  end
+                end
+                b[#b] = "\n      "
              end
-             b[#b] = "\n      "
-          end


### PR DESCRIPTION
Lmod 8.2 added an interesting we can use (mostly relevant for login nodes)

Integration tests still pass with flying colors:

```
-bash-4.2$ ./run_all_tests.sh
Lmod-8.2.5-1.ug.el7.x86_64
vsc-cluster-modules-0.36-1.noarch
vsc-cluster-modules-tier2-0.36-1.noarch

> module --version

Modules based on Lua: Version 8.2.5  2019-11-25 15:29 -06:00
$MODULEPATH: /apps/gent/CO7/haswell-ib/modules/all:/etc/modulefiles/vsc

*** 001_list.sh ***

> module list

>>> 001_list.sh: PASS

*** 002_avail.sh ***

> module avail
> module avail GCC
> module avail GCC/6.4.0

>>> 002_avail.sh: PASS

*** 003_load.sh ***

> module load GCC
> module load GCC/6.4.0-2.28
> module load intel
> module load foss
> module load Python/2.7.14-intel-2018a
> module load GCC/6.4.0-2.28 OpenMPI/2.1.2-GCC-6.4.0-2.28 OpenBLAS/0.2.20-GCC-6.4.0-2.28 FFTW/3.3.7-gompi-2018a
> module --force purge; module load cluster  # with 1 seconds time limit

>>> 003_load.sh: PASS

*** 004_purge.sh ***

> module load Python/2.7.14-intel-2018a
> module purge
> module load cluster
> module --force purge
> module load cluster
> module --force purge
> module load cluster/swalot

>>> 004_purge.sh: PASS

*** 005_swap.sh ***

> module load GCCcore/6.4.0
> module swap GCCcore/7.3.0
> module swap GCCcore GCCcore/6.4.0
> module swap GCCcore/6.4.0 GCCcore/7.3.0

>>> 005_swap.sh: PASS

*** 006_unload.sh ***

> module load GCCcore/6.4.0
> module unload GCCcore
> module load GCCcore/6.4.0
> module unload GCCcore/6.4.0

>>> 006_unload.sh: PASS

*** 007_spider.sh ***

> module spider intel
> module spider intel/2016a
> module --show-hidden spider intel/2016a

>>> 007_spider.sh: PASS

*** 010_stdout_stderr.sh ***

> module list
> module avail

>>> 010_stdout_stderr.sh: PASS

*** 050_ml.sh ***

> ml av GCCcore/6.4.0
> ml
> ml GCCcore/6.4.0
> ml
> ml -GCCcore/6.4.0
> ml

>>> 050_ml.sh: PASS

*** 051_collections.sh ***

> ml foss/2018a
> ml Python/2.7.14-intel-2018a
> module swap cluster/delcatty
> ml save this_is_just_a_test_collection_for_module_integration_test_051
> ml describe this_is_just_a_test_collection_for_module_integration_test_051
> module swap cluster/swalot
> ml save this_is_just_a_test_collection_for_module_integration_test_051
> ml describe this_is_just_a_test_collection_for_module_integration_test_051
> ml purge
> ml restore this_is_just_a_test_collection_for_module_integration_test_051
> ml purge
> module swap cluster/delcatty
> ml purge
> ml restore this_is_just_a_test_collection_for_module_integration_test_051
> ml purge

>>> 051_collections.sh: PASS

*** 100_lmod_cache.sh ***

> module avail  # 2s time limit

>>> 100_lmod_cache.sh: PASS

*** 101_LD_LIBRARY_PATH.sh ***

> module load GCC/6.4.0-2.28
> module load OpenMPI/2.1.2-GCC-6.4.0-2.28
> checking $LD_LIBRARY_PATH...

>>> 101_LD_LIBRARY_PATH.sh: PASS

*** 102_symlink_modulepath.sh ***

> module use /tmp/vsc40023/pM0MiZ/symlinked_modules
> module avail test/1.2.3

>>> 102_symlink_modulepath.sh: PASS

*** 103_tcl2lua_LD_PRELOAD.sh ***

> module load jemalloc
> module show jemalloc
> ml intel/2018a && LD_LIBRARY_PATH='' LD_PRELOAD='' ml MariaDB/10.3.7-intel-2018a

>>> 103_tcl2lua_LD_PRELOAD.sh: PASS

TEST RESULT: all 14 passed!