### PR TITLE
also compile Lmod spider cache with alternate Lua versions (+ update to Lmod 8.4.10) (HPC-8637)

### DIFF
--- a/Lmod-UGent.spec
+++ b/Lmod-UGent.spec
@@ -101,7 +101,7 @@ rm -rf %{buildroot}
 
 
 %changelog
-* Mon Oct 26 2020 Kenneth Hoste <kenneth.hoste@ugent.be> - 8.4.10-1.ug
+* Mon Oct 26 2020 Kenneth Hoste <kenneth.hoste@ugent.be> - 8.4.10-2.ug
   - update to Lmod 8.4.10 and add patch to also compile Lmod spider cache with alternate Lua versions
 
 * Mon Aug 31 2020 Kenneth Hoste <kenneth.hoste@ugent.be> - 8.4.2-1.ug

--- a/Lmod-UGent.spec
+++ b/Lmod-UGent.spec
@@ -1,7 +1,7 @@
 %global macrosdir %(d=%{_rpmconfigdir}/macros.d; [ -d $d ] || d=%{_sysconfdir}/rpm; echo $d)
 
 Name:           Lmod
-Version:        8.4.2
+Version:        8.4.10
 Release:        1.ug%{?dist}
 Summary:        Environmental Modules System in Lua
 
@@ -14,6 +14,7 @@ Source2:        SitePackage.lua
 Source3:        run_lmod_cache.py
 Source4:        admin.list
 Patch0:         Lmod-spider-no-hidden-cluster-modules.patch
+Patch1:         Lmod-compile-cache-alt-lua-versions.patch
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 # Lmod 8.x ships binaries when configured with --with-fastTCLInterp=yes (which is the default)
@@ -50,6 +51,7 @@ where the library and header files can be found.
 %prep
 %setup -q
 %patch0 -p1
+%patch1 -p1
 sed -i -e 's,/usr/bin/env ,/usr/bin/,' src/*.tcl
 # Remove bundled lua-term
 rm -r pkgs/luafilesystem/ pkgs/term/ tools/json.lua
@@ -99,6 +101,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Mon Oct 26 2020 Kenneth Hoste <kenneth.hoste@ugent.be> - 8.4.10-1.ug
+  - update to Lmod 8.4.10 and add patch to also compile Lmod spider cache with alternate Lua versions
+
 * Mon Aug 31 2020 Kenneth Hoste <kenneth.hoste@ugent.be> - 8.4.2-1.ug
   - update to Lmod 8.4.2 + add 'Provides: environment(modules)' to spec file
 

--- a/Lmod-UGent.spec
+++ b/Lmod-UGent.spec
@@ -2,7 +2,7 @@
 
 Name:           Lmod
 Version:        8.4.10
-Release:        1.ug%{?dist}
+Release:        2.ug%{?dist}
 Summary:        Environmental Modules System in Lua
 
 # Lmod-5.3.2/tools/base64.lua is LGPLv2

--- a/Lmod-compile-cache-alt-lua-versions.patch
+++ b/Lmod-compile-cache-alt-lua-versions.patch
@@ -1,3 +1,5 @@
+see also https://github.com/TACC/Lmod/pull/475
+
 commit ae104381f8a70580cabd4938d53d392fffb4112a
 Author: Kenneth Hoste <kenneth.hoste@ugent.be>
 Date:   Mon Oct 26 11:05:02 2020 +0100

--- a/Lmod-compile-cache-alt-lua-versions.patch
+++ b/Lmod-compile-cache-alt-lua-versions.patch
@@ -1,11 +1,11 @@
-commit 53f6278d8a655622843be842b9f0e50f70841af4
+commit ae104381f8a70580cabd4938d53d392fffb4112a
 Author: Kenneth Hoste <kenneth.hoste@ugent.be>
-Date:   Mon Oct 26 10:49:32 2020 +0100
+Date:   Mon Oct 26 11:05:02 2020 +0100
 
     also compile Lmod spider cache for alternate Lua versions if corresponding luac command is available
 
 diff --git a/src/update_lmod_system_cache_files.in b/src/update_lmod_system_cache_files.in
-index e3a089ae..5daf8127 100644
+index e3a089ae..37d82bee 100644
 --- a/src/update_lmod_system_cache_files.in
 +++ b/src/update_lmod_system_cache_files.in
 @@ -308,6 +308,18 @@ update_cache() {
@@ -14,7 +14,7 @@ index e3a089ae..5daf8127 100644
         install_new_cache luac_$lua_ver ${cache_file_name}
 +
 +       # also compile cache with other Lua 5.x versions, if corresponding luac is available
-+       for alt_luac in $(ls @path_to_luac@-5.*); do
++       for alt_luac in $(ls @path_to_luac@-5.* 2> /dev/null); do
 +           alt_lua_ver=$(basename ${alt_luac} | cut -f2 -d'-')
 +           debug "Found potential alternate Lua version ${alt_lua_ver} (via ${alt_luac}"
 +           # only for Lua versions different than what lua/luac commands correspond to (see above)

--- a/Lmod-compile-cache-alt-lua-versions.patch
+++ b/Lmod-compile-cache-alt-lua-versions.patch
@@ -1,0 +1,30 @@
+commit 53f6278d8a655622843be842b9f0e50f70841af4
+Author: Kenneth Hoste <kenneth.hoste@ugent.be>
+Date:   Mon Oct 26 10:49:32 2020 +0100
+
+    also compile Lmod spider cache for alternate Lua versions if corresponding luac command is available
+
+diff --git a/src/update_lmod_system_cache_files.in b/src/update_lmod_system_cache_files.in
+index e3a089ae..5daf8127 100644
+--- a/src/update_lmod_system_cache_files.in
++++ b/src/update_lmod_system_cache_files.in
+@@ -308,6 +308,18 @@ update_cache() {
+        lua_ver=$(@path_to_lua@/lua -e 'print((_VERSION:gsub("Lua ","")))')
+        @path_to_luac@ -o ${cache_file_name}.new.luac_$lua_ver ${cache_file_name}.lua
+        install_new_cache luac_$lua_ver ${cache_file_name}
++
++       # also compile cache with other Lua 5.x versions, if corresponding luac is available
++       for alt_luac in $(ls @path_to_luac@-5.*); do
++           alt_lua_ver=$(basename ${alt_luac} | cut -f2 -d'-')
++           debug "Found potential alternate Lua version ${alt_lua_ver} (via ${alt_luac}"
++           # only for Lua versions different than what lua/luac commands correspond to (see above)
++           if [ "${alt_lua_ver}" != "${lua_ver}" ]; then
++               debug "Compiling cache file ${cache_file_name} for Lua ${alt_lua_ver}..."
++               ${alt_luac} -o ${cache_file_name}.new.luac_${alt_lua_ver} ${cache_file_name}.lua
++               install_new_cache luac_${alt_lua_ver} ${cache_file_name}
++           fi
++       done
+     fi
+ }
+ 
+


### PR DESCRIPTION
tested on `gligar06` (both re-generating Lmod cache + Lmod update), works like charm

see also https://github.com/TACC/Lmod/pull/475