### PR TITLE
update to Lmod 8.4.12

### DIFF
--- a/Lmod-UGent.spec
+++ b/Lmod-UGent.spec
@@ -1,8 +1,8 @@
 %global macrosdir %(d=%{_rpmconfigdir}/macros.d; [ -d $d ] || d=%{_sysconfdir}/rpm; echo $d)
 
 Name:           Lmod
-Version:        8.4.2
-Release:        2.ug%{?dist}
+Version:        8.4.12
+Release:        1.ug%{?dist}
 Summary:        Environmental Modules System in Lua
 
 # Lmod-5.3.2/tools/base64.lua is LGPLv2
@@ -101,6 +101,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Thu Nov 5 2020 Kenneth Hoste <kenneth.hoste@ugent.be> - 8.4.12-1.ug
+  - update to Lmod 8.4.12
+
 * Mon Oct 26 2020 Kenneth Hoste <kenneth.hoste@ugent.be> - 8.4.2-2.ug
   - roll back to Lmod 8.4.2 because of bug in Lmod 8.4.10 (https://github.com/TACC/Lmod/issues/476)
 


### PR DESCRIPTION
Tested more carefully this time, also made sure that Lmod cache created with Lmod 8.4.12 can be consumed without problems by our current Lmod installation (8.4.2).

The bug that caused us to roll back (see #44) after updating to Lmod 8.4.10 (#43) is fixed in Lmod 8.4.12, see https://github.com/TACC/Lmod/issues/476.

Integration tests also pass with Lmod 8.4.12:

```
$ ./run_all_tests.sh
Lmod-8.4.12-1.ug.el7.x86_64
vsc-cluster-modules-0.42-1.noarch
vsc-cluster-modules-tier2-0.42-1.noarch

> module --version

Modules based on Lua: Version 8.4.12  2020-10-31 10:02 -05:00
$MODULEPATH: /apps/gent/CO7/skylake-ib/modules/all:/etc/modulefiles/vsc

*** 001_list.sh ***

> module list

>>> 001_list.sh: PASS

*** 002_avail.sh ***

> module avail
> module avail GCC
> module avail GCC/6.4.0

>>> 002_avail.sh: PASS

*** 003_load.sh ***

> module load GCC
> module load GCC/6.4.0-2.28
> module load intel
> module load foss
> module load Python/2.7.14-intel-2018a
> module load GCC/6.4.0-2.28 OpenMPI/2.1.2-GCC-6.4.0-2.28 OpenBLAS/0.2.20-GCC-6.4.0-2.28 FFTW/3.3.7-gompi-2018a
> module --force purge; module load cluster  # with 1 seconds time limit

>>> 003_load.sh: PASS

*** 004_purge.sh ***

> module load Python/2.7.14-intel-2018a
> module purge
> module load cluster
> module --force purge
> module load cluster
> module --force purge
> module load cluster/skitty

>>> 004_purge.sh: PASS

*** 005_swap.sh ***

> module load GCCcore/6.4.0
> module swap GCCcore/7.3.0
> module swap GCCcore GCCcore/6.4.0
> module swap GCCcore/6.4.0 GCCcore/7.3.0

>>> 005_swap.sh: PASS

*** 006_unload.sh ***

> module load GCCcore/6.4.0
> module unload GCCcore
> module load GCCcore/6.4.0
> module unload GCCcore/6.4.0

>>> 006_unload.sh: PASS

*** 007_spider.sh ***

> module spider intel
> module spider intel/2016a
> module --show-hidden spider intel/2016a

>>> 007_spider.sh: PASS

*** 010_stdout_stderr.sh ***

> module list
> module avail

>>> 010_stdout_stderr.sh: PASS

*** 050_ml.sh ***

> ml av GCCcore/6.4.0
> ml
> ml GCCcore/6.4.0
> ml
> ml -GCCcore/6.4.0
> ml

>>> 050_ml.sh: PASS

*** 051_collections.sh ***

> ml foss/2018a
> ml Python/2.7.14-intel-2018a
> module swap cluster/golett
> ml save this_is_just_a_test_collection_for_module_integration_test_051
> ml describe this_is_just_a_test_collection_for_module_integration_test_051
> module swap cluster/skitty
> ml save this_is_just_a_test_collection_for_module_integration_test_051
> ml describe this_is_just_a_test_collection_for_module_integration_test_051
> ml purge
> ml restore this_is_just_a_test_collection_for_module_integration_test_051
> ml purge
> module swap cluster/golett
> ml purge
> ml restore this_is_just_a_test_collection_for_module_integration_test_051
> ml purge

>>> 051_collections.sh: PASS

*** 100_lmod_cache.sh ***

> module avail  # 2s time limit

>>> 100_lmod_cache.sh: PASS

*** 101_LD_LIBRARY_PATH.sh ***

> module load GCC/6.4.0-2.28
> module load OpenMPI/2.1.2-GCC-6.4.0-2.28
> checking $LD_LIBRARY_PATH...

>>> 101_LD_LIBRARY_PATH.sh: PASS

*** 102_symlink_modulepath.sh ***

> module use /tmp/vsc40023/Z7lGBZ/symlinked_modules
> module avail test/1.2.3

>>> 102_symlink_modulepath.sh: PASS

*** 103_tcl2lua_LD_PRELOAD.sh ***

> module load jemalloc/5.0.1-GCCcore-6.4.0
> module show jemalloc/5.0.1-GCCcore-6.4.0
> ml intel/2018a && LD_LIBRARY_PATH='' LD_PRELOAD='' ml MariaDB/10.3.7-intel-2018a

>>> 103_tcl2lua_LD_PRELOAD.sh: PASS

TEST RESULT: all 14 passed!
```
