### PR TITLE
update to Lmod 8.7.4

### DIFF
--- a/Lmod-UGent.spec
+++ b/Lmod-UGent.spec
@@ -1,8 +1,8 @@
 %global macrosdir %(d=%{_rpmconfigdir}/macros.d; [ -d $d ] || d=%{_sysconfdir}/rpm; echo $d)
 
 Name:           Lmod
-Version:        8.4.12
-Release:        3.ug%{?dist}
+Version:        8.7.4
+Release:        1.ug%{?dist}
 Summary:        Environmental Modules System in Lua
 
 # Lmod-5.3.2/tools/base64.lua is LGPLv2
@@ -114,6 +114,9 @@ rm -rf %{buildroot}
 %{_datadir}/lmod
 
 %changelog
+* Wed Jun 8 2022 Kenneth Hoste <kenneth.hoste@ugent.be> - 8.7.4-1.ug
+  - update to Lmod 8.7.4
+
 * Thu Nov 5 2020 Kenneth Hoste <kenneth.hoste@ugent.be> - 8.4.12-1.ug
   - update to Lmod 8.4.12
 

--- a/Lmod-compile-cache-alt-lua-versions.patch
+++ b/Lmod-compile-cache-alt-lua-versions.patch
@@ -1,5 +1,5 @@
 see also https://github.com/TACC/Lmod/pull/475
-
+-
 commit ae104381f8a70580cabd4938d53d392fffb4112a
 Author: Kenneth Hoste <kenneth.hoste@ugent.be>
 Date:   Mon Oct 26 11:05:02 2020 +0100
@@ -7,11 +7,11 @@ Date:   Mon Oct 26 11:05:02 2020 +0100
     also compile Lmod spider cache for alternate Lua versions if corresponding luac command is available
 
 diff --git a/src/update_lmod_system_cache_files.in b/src/update_lmod_system_cache_files.in
-index e3a089ae..37d82bee 100644
+index 7e7e46a4..82097377 100644
 --- a/src/update_lmod_system_cache_files.in
 +++ b/src/update_lmod_system_cache_files.in
-@@ -308,6 +308,18 @@ update_cache() {
-        lua_ver=$(@path_to_lua@/lua -e 'print((_VERSION:gsub("Lua ","")))')
+@@ -319,6 +319,18 @@ update_cache() {
+        lua_ver=$(@path_to_lua@ -e 'print((_VERSION:gsub("Lua ","")))')
         @path_to_luac@ -o ${cache_file_name}.new.luac_$lua_ver ${cache_file_name}.lua
         install_new_cache luac_$lua_ver ${cache_file_name}
 +
@@ -29,4 +29,3 @@ index e3a089ae..37d82bee 100644
      fi
  }
  
-

--- a/Lmod-spider-no-hidden-cluster-modules.patch
+++ b/Lmod-spider-no-hidden-cluster-modules.patch
@@ -1,10 +1,12 @@
+don't show hidden cluster modules in output of 'module spider'
+
 diff --git a/src/Spider.lua b/src/Spider.lua
-index 095a8f44..ec89b33b 100644
+index 25999e19..cf305843 100644
 --- a/src/Spider.lua
 +++ b/src/Spider.lua
-@@ -1282,8 +1282,10 @@ function M._Level2(self, sn, fullName, entryA, entryPA, possibleA, tailMsg)
-             for j = 1, #entryT.parentAA do
-                local parentA = entryT.parentAA[j]
+@@ -1390,8 +1390,10 @@ function M._Level2(self, sn, fullName, entryA, entryPA, possibleA, tailMsg)
+             for j = 1, #my_entryT.parentAA do
+                local parentA = my_entryT.parentAA[j]
                 for i = 1, #parentA do
 -                  b[#b+1] = parentA[i]
 -                  b[#b+1] = '  '


### PR DESCRIPTION
Integration tests still pass:

```
$ ./run_all_tests.sh
Lmod-8.7.4-1.ug.el8.x86_64
Lmod-core-8.7.4-1.ug.el8.x86_64
vsc-cluster-modules-1.0-1.noarch
vsc-cluster-modules-tier2-1.0-1.noarch

> module --version

Modules based on Lua: Version 8.7.4  2022-06-07 18:23 -05:00
$MODULEPATH: /apps/gent/RHEL8/haswell-ib/modules/all:/etc/modulefiles/vsc

*** 001_list.sh ***

> module list

>>> 001_list.sh: PASS

*** 002_avail.sh ***

> module avail
> module avail GCC
> module avail GCC/10.3.0

>>> 002_avail.sh: PASS

*** 003_load.sh ***

> module load GCC
> module load GCC/10.3.0
> module load intel
> module load foss
> module load Python/3.9.5-GCCcore-10.3.0
> module load GCC/10.3.0 OpenMPI/4.1.1-GCC-10.3.0 FlexiBLAS/3.0.4-GCC-10.3.0 FFTW/3.3.9-gompi-2021a
> module --force purge; module load cluster  # with 1 seconds time limit

>>> 003_load.sh: PASS

*** 004_purge.sh ***

> module load Python/3.9.5-GCCcore-10.3.0
> module purge
> module load cluster
> module --force purge
> module load cluster
> module --force purge
> module load cluster/swalot

>>> 004_purge.sh: PASS

*** 005_swap.sh ***

> module load GCCcore/10.3.0
> module swap GCCcore/11.2.0
> module swap GCCcore GCCcore/10.3.0
> module swap GCCcore/10.3.0 GCCcore/11.2.0

>>> 005_swap.sh: PASS

*** 006_unload.sh ***

> module load GCCcore/10.3.0
> module unload GCCcore
> module load GCCcore/10.3.0
> module unload GCCcore/10.3.0

>>> 006_unload.sh: PASS

*** 007_spider.sh ***

> module spider intel
> module spider intel/2020b
> module --show-hidden spider intel/2020b

>>> 007_spider.sh: PASS

*** 010_stdout_stderr.sh ***

> module list
> module avail

>>> 010_stdout_stderr.sh: PASS

*** 050_ml.sh ***

> ml av GCCcore/10.3.0
> ml
> ml GCCcore/10.3.0
> ml
> ml -GCCcore/10.3.0
> ml

>>> 050_ml.sh: PASS

*** 051_collections.sh ***

> ml foss/2020b
> ml Python/2.7.18-GCCcore-10.2.0
> module swap cluster/accelgor
> ml save this_is_just_a_test_collection_for_module_integration_test_051
> ml describe this_is_just_a_test_collection_for_module_integration_test_051
> module swap cluster/swalot
> ml save this_is_just_a_test_collection_for_module_integration_test_051
> ml describe this_is_just_a_test_collection_for_module_integration_test_051
> ml purge
> ml restore this_is_just_a_test_collection_for_module_integration_test_051
> ml purge
> module swap cluster/accelgor
> ml purge
> ml restore this_is_just_a_test_collection_for_module_integration_test_051
> ml purge

>>> 051_collections.sh: PASS

*** 100_lmod_cache.sh ***

> module avail  # 2s time limit

>>> 100_lmod_cache.sh: PASS

*** 101_LD_LIBRARY_PATH.sh ***

> module load GCC/10.3.0
> module load OpenMPI/4.1.1-GCC-10.3.0
> checking $LD_LIBRARY_PATH...

>>> 101_LD_LIBRARY_PATH.sh: PASS

*** 102_symlink_modulepath.sh ***

> module use /tmp/vsc40023/Cevivj/symlinked_modules
> module avail test/1.2.3

>>> 102_symlink_modulepath.sh: PASS

TEST RESULT: all 13 passed!
```